### PR TITLE
refacto: move use case interfaces for product management including cr…

### DIFF
--- a/backend/application/src/main/java/com/example/application/product/port/in/CreateProductUseCase.java
+++ b/backend/application/src/main/java/com/example/application/product/port/in/CreateProductUseCase.java
@@ -1,4 +1,4 @@
-package com.example.domain.product.port.in;
+package com.example.application.product.port.in;
 
 import com.example.domain.product.Product;
 

--- a/backend/application/src/main/java/com/example/application/product/port/in/DeleteProductUseCase.java
+++ b/backend/application/src/main/java/com/example/application/product/port/in/DeleteProductUseCase.java
@@ -1,4 +1,4 @@
-package com.example.domain.product.port.in;
+package com.example.application.product.port.in;
 
 import com.example.domain.product.ProductId;
 

--- a/backend/application/src/main/java/com/example/application/product/port/in/GetProductsUseCase.java
+++ b/backend/application/src/main/java/com/example/application/product/port/in/GetProductsUseCase.java
@@ -1,4 +1,4 @@
-package com.example.domain.product.port.in;
+package com.example.application.product.port.in;
 
 import java.util.List;
 import java.util.Optional;

--- a/backend/application/src/main/java/com/example/application/product/port/in/UpdateProductUseCase.java
+++ b/backend/application/src/main/java/com/example/application/product/port/in/UpdateProductUseCase.java
@@ -1,4 +1,4 @@
-package com.example.domain.product.port.in;
+package com.example.application.product.port.in;
 
 import com.example.domain.product.Product;
 

--- a/backend/application/src/main/java/com/example/application/product/port/out/ProductRepository.java
+++ b/backend/application/src/main/java/com/example/application/product/port/out/ProductRepository.java
@@ -1,4 +1,4 @@
-package com.example.domain.product.port.out;
+package com.example.application.product.port.out;
 
 import java.util.List;
 import java.util.Optional;


### PR DESCRIPTION
This pull request reorganizes the location of several product-related use case interfaces by moving them from the `domain` layer to the `application` layer. This helps clarify the application architecture by ensuring that use case interfaces are placed within the appropriate layer, following clean architecture principles.

**Refactoring and package restructuring:**

* Moved `CreateProductUseCase`, `DeleteProductUseCase`, `GetProductsUseCase`, and `UpdateProductUseCase` interfaces from `com.example.domain.product.port.in` to `com.example.application.product.port.in`, updating their package declarations and file locations accordingly. [[1]](diffhunk://#diff-6f0f35898e2d4b150d7c608d1000bc581e75d00fe391687f466ffa199660b777L1-R1) [[2]](diffhunk://#diff-3876352b47e9a786e1046da5b7b6ea1346d7b6ec45eea8049f9a130a43d3d7e0L1-R1) [[3]](diffhunk://#diff-afbb55c846f1767f8adb5bd9d40af88a4ff9f3ca61b623f90985f412f5442fb5L1-R1) [[4]](diffhunk://#diff-c8ddd5c31403812be91133ed94c31490bdf4097933738f4dcfaf7309cd2ad9e5L1-R1)