### PR TITLE
feat: implement ProductService with CRUD operations and validation logic

### DIFF
--- a/backend/application/src/main/java/com/example/application/product/service/ProductService.java
+++ b/backend/application/src/main/java/com/example/application/product/service/ProductService.java
@@ -1,0 +1,88 @@
+package com.example.application.product.service;
+
+import java.util.List;
+import java.util.Optional;
+
+import com.example.application.product.port.in.CreateProductUseCase;
+import com.example.application.product.port.in.DeleteProductUseCase;
+import com.example.application.product.port.in.GetProductsUseCase;
+import com.example.application.product.port.in.UpdateProductUseCase;
+import com.example.application.product.port.out.ProductRepository;
+import com.example.domain.product.Product;
+import com.example.domain.product.ProductId;
+
+/**
+ * Application service implementing all product-related use cases.
+ * Acts as the primary entry point to product management functionality.
+ */
+public class ProductService implements CreateProductUseCase, UpdateProductUseCase, 
+                                      DeleteProductUseCase, GetProductsUseCase {
+
+    private final ProductRepository productRepository;
+
+    public ProductService(ProductRepository productRepository) {
+        this.productRepository = productRepository;
+    }
+
+    @Override
+    public Product create(Product product) {
+        // Check for duplicate product code
+        if (productRepository.existsByCode(product.getCode())) {
+            throw new IllegalArgumentException("Product with code " + product.getCode() + " already exists");
+        }
+        
+        // Set creation/update timestamps if they're not already set
+        long currentTime = System.currentTimeMillis();
+        if (product.getCreatedAt() == 0) {
+            product.setCreatedAt(currentTime);
+        }
+        if (product.getUpdatedAt() == 0) {
+            product.setUpdatedAt(currentTime);
+        }
+        
+        return productRepository.save(product);
+    }
+
+    @Override
+    public Product update(Product product) {
+        // Verify product exists
+        ProductId id = product.getId();
+        if (!productRepository.findById(id).isPresent()) {
+            throw new IllegalArgumentException("Product with id " + id + " does not exist");
+        }
+        
+        // Check if updating to a code that already exists on another product
+        Optional<Product> existingProductWithCode = productRepository.findAll().stream()
+            .filter(p -> p.getCode().equals(product.getCode()) && !p.getId().equals(id))
+            .findFirst();
+            
+        if (existingProductWithCode.isPresent()) {
+            throw new IllegalArgumentException("Product with code " + product.getCode() + " already exists");
+        }
+        
+        // Update timestamp
+        product.setUpdatedAt(System.currentTimeMillis());
+        
+        return productRepository.save(product);
+    }
+
+    @Override
+    public void deleteById(ProductId id) {
+        // Verify product exists before deletion
+        if (!productRepository.findById(id).isPresent()) {
+            throw new IllegalArgumentException("Product with id " + id + " does not exist");
+        }
+        
+        productRepository.deleteById(id);
+    }
+
+    @Override
+    public Optional<Product> getById(ProductId id) {
+        return productRepository.findById(id);
+    }
+
+    @Override
+    public List<Product> getAll() {
+        return productRepository.findAll();
+    }
+}

--- a/backend/application/src/test/java/com/example/application/product/service/ProductServiceTest.java
+++ b/backend/application/src/test/java/com/example/application/product/service/ProductServiceTest.java
@@ -1,0 +1,218 @@
+package com.example.application.product.service;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import static org.mockito.ArgumentMatchers.any;
+import org.mockito.Mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import org.mockito.MockitoAnnotations;
+
+import com.example.application.product.port.out.ProductRepository;
+import com.example.domain.product.Product;
+import com.example.domain.product.ProductId;
+
+class ProductServiceTest {
+
+    @Mock
+    private ProductRepository productRepository;
+    
+    private ProductService productService;
+    
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        productService = new ProductService(productRepository);
+    }
+    
+    @Test
+    void createProduct_ShouldSaveAndReturnProduct() {
+        // Arrange
+        Product product = createTestProduct();
+        when(productRepository.existsByCode(product.getCode())).thenReturn(false);
+        when(productRepository.save(any(Product.class))).thenReturn(product);
+        
+        // Act
+        Product result = productService.create(product);
+        
+        // Assert
+        assertNotNull(result);
+        assertEquals(product, result);
+        verify(productRepository).existsByCode(product.getCode());
+        verify(productRepository).save(product);
+    }
+    
+    @Test
+    void createProduct_WithDuplicateCode_ShouldThrowException() {
+        // Arrange
+        Product product = createTestProduct();
+        when(productRepository.existsByCode(product.getCode())).thenReturn(true);
+        
+        // Act & Assert
+        Exception exception = assertThrows(IllegalArgumentException.class, () -> {
+            productService.create(product);
+        });
+        
+        assertTrue(exception.getMessage().contains("already exists"));
+        verify(productRepository).existsByCode(product.getCode());
+        verify(productRepository, never()).save(any(Product.class));
+    }
+    
+    @Test
+    void updateProduct_ShouldUpdateAndReturnProduct() {
+        // Arrange
+        Product product = createTestProduct();
+        when(productRepository.findById(product.getId())).thenReturn(Optional.of(product));
+        when(productRepository.findAll()).thenReturn(List.of(product));
+        when(productRepository.save(any(Product.class))).thenReturn(product);
+        
+        // Act
+        Product result = productService.update(product);
+        
+        // Assert
+        assertNotNull(result);
+        assertEquals(product, result);
+        verify(productRepository).findById(product.getId());
+        verify(productRepository).save(product);
+    }
+    
+    @Test
+    void updateProduct_WithNonExistentId_ShouldThrowException() {
+        // Arrange
+        Product product = createTestProduct();
+        when(productRepository.findById(product.getId())).thenReturn(Optional.empty());
+        
+        // Act & Assert
+        Exception exception = assertThrows(IllegalArgumentException.class, () -> {
+            productService.update(product);
+        });
+        
+        assertTrue(exception.getMessage().contains("does not exist"));
+        verify(productRepository).findById(product.getId());
+        verify(productRepository, never()).save(any(Product.class));
+    }
+    
+    @Test
+    void updateProduct_WithDuplicateCode_ShouldThrowException() {
+        // Arrange
+        Product product1 = createTestProduct();
+        Product product2 = createTestProduct();
+        product2.setId(ProductId.newId()); // Different ID
+        
+        when(productRepository.findById(product1.getId())).thenReturn(Optional.of(product1));
+        when(productRepository.findAll()).thenReturn(Arrays.asList(product1, product2));
+        
+        // Act & Assert
+        Exception exception = assertThrows(IllegalArgumentException.class, () -> {
+            productService.update(product1);
+        });
+        
+        assertTrue(exception.getMessage().contains("already exists"));
+        verify(productRepository).findById(product1.getId());
+        verify(productRepository, never()).save(any(Product.class));
+    }
+    
+    @Test
+    void deleteProduct_ShouldDeleteExistingProduct() {
+        // Arrange
+        ProductId id = ProductId.newId();
+        when(productRepository.findById(id)).thenReturn(Optional.of(createTestProduct()));
+        
+        // Act
+        productService.deleteById(id);
+        
+        // Assert
+        verify(productRepository).findById(id);
+        verify(productRepository).deleteById(id);
+    }
+    
+    @Test
+    void deleteProduct_WithNonExistentId_ShouldThrowException() {
+        // Arrange
+        ProductId id = ProductId.newId();
+        when(productRepository.findById(id)).thenReturn(Optional.empty());
+        
+        // Act & Assert
+        Exception exception = assertThrows(IllegalArgumentException.class, () -> {
+            productService.deleteById(id);
+        });
+        
+        assertTrue(exception.getMessage().contains("does not exist"));
+        verify(productRepository).findById(id);
+        verify(productRepository, never()).deleteById(any(ProductId.class));
+    }
+    
+    @Test
+    void getById_ShouldReturnProduct() {
+        // Arrange
+        ProductId id = ProductId.newId();
+        Product product = createTestProduct();
+        when(productRepository.findById(id)).thenReturn(Optional.of(product));
+        
+        // Act
+        Optional<Product> result = productService.getById(id);
+        
+        // Assert
+        assertTrue(result.isPresent());
+        assertEquals(product, result.get());
+        verify(productRepository).findById(id);
+    }
+    
+    @Test
+    void getById_WithNonExistentId_ShouldReturnEmpty() {
+        // Arrange
+        ProductId id = ProductId.newId();
+        when(productRepository.findById(id)).thenReturn(Optional.empty());
+        
+        // Act
+        Optional<Product> result = productService.getById(id);
+        
+        // Assert
+        assertFalse(result.isPresent());
+        verify(productRepository).findById(id);
+    }
+    
+    @Test
+    void getAll_ShouldReturnAllProducts() {
+        // Arrange
+        List<Product> products = List.of(createTestProduct(), createTestProduct());
+        when(productRepository.findAll()).thenReturn(products);
+        
+        // Act
+        List<Product> result = productService.getAll();
+        
+        // Assert
+        assertEquals(2, result.size());
+        assertEquals(products, result);
+        verify(productRepository).findAll();
+    }
+    
+    private Product createTestProduct() {
+        return new Product(
+            ProductId.newId(),
+            "TEST-001",
+            "Test Product",
+            "Test Description",
+            new byte[0],
+            "Test Category",
+            99.99,
+            10,
+            "INT-REF-001",
+            1,
+            Product.InventoryStatus.INSTOCK,
+            4,
+            System.currentTimeMillis(),
+            System.currentTimeMillis()
+        );
+    }
+}

--- a/backend/domain/src/main/java/com/example/domain/product/Product.java
+++ b/backend/domain/src/main/java/com/example/domain/product/Product.java
@@ -61,8 +61,14 @@ public class Product {
     public void setShellId(int shellId) { this.shellId = shellId; }
     public InventoryStatus getInventoryStatus() { return inventoryStatus; }
     public void setInventoryStatus(InventoryStatus inventoryStatus) { this.inventoryStatus = inventoryStatus; }
+    public int getRating() { return rating; }
+    public void setRating(int rating) { this.rating = rating; }
+    public long getCreatedAt() { return createdAt; }
+    public void setCreatedAt(long createdAt) { this.createdAt = createdAt; }
+    public long getUpdatedAt() { return updatedAt; }
+    public void setUpdatedAt(long updatedAt) { this.updatedAt = updatedAt; }
 
-
+    
 }
 
 


### PR DESCRIPTION
This pull request introduces a new `ProductService` class that implements all product-related use cases and adds comprehensive unit tests for its functionality. Additionally, it enhances the `Product` domain model by exposing getter and setter methods for the `rating`, `createdAt`, and `updatedAt` fields.

**Core application logic:**

* Added `ProductService`, an application service that implements the main product use cases (`CreateProductUseCase`, `UpdateProductUseCase`, `DeleteProductUseCase`, and `GetProductsUseCase`). It handles product creation, updating, deletion, and retrieval, including business logic for duplicate code checks and timestamp management.

**Testing improvements:**

* Introduced `ProductServiceTest`, a unit test class that verifies all major behaviors of `ProductService`, including handling of duplicates, non-existent products, and correct repository interactions using Mockito.

**Domain model enhancements:**

* Added getter and setter methods for `rating`, `createdAt`, and `updatedAt` fields in the `Product` class to support the new service logic and testing.