### PR TITLE
feat: Add actuator dependency and management endpoints

### DIFF
--- a/backend/boot/pom.xml
+++ b/backend/boot/pom.xml
@@ -52,6 +52,10 @@
         <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
         <version>${springdoc.version}</version>
     </dependency>
+    <dependency>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-actuator</artifactId>
+    </dependency>
   </dependencies>
 
   <build>

--- a/backend/boot/src/main/resources/application.yml
+++ b/backend/boot/src/main/resources/application.yml
@@ -26,3 +26,12 @@ springdoc:
     enabled: true
   default-produces-media-type: application/json
   default-consumes-media-type: application/json
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info
+  endpoint:
+    health:
+      show-details: always


### PR DESCRIPTION
This pull request adds support for Spring Boot Actuator to the project, enabling health and info management endpoints. The changes include updating dependencies and configuring which management endpoints are exposed and how much detail is shown.

**Spring Boot Actuator integration and configuration:**

* Added the `spring-boot-starter-actuator` dependency in `pom.xml` to enable actuator features for monitoring and management.
* Updated `application.yml` to expose the `health` and `info` management endpoints over the web, and configured the health endpoint to always show details.